### PR TITLE
modified top page responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,13 +52,8 @@
 				</div>
 				<div class="pb-4 d-flex justify-content-center">
 					<img
-<<<<<<< HEAD
 						width="60%"
 						height="60%"
-=======
-						width="100%"
-						height="100%"
->>>>>>> c541d9e336b22a719f2d479475778fd1460b0b36
 						src="./img/ramen_moyashi.png"
 						alt="なんかいい画像"
 					/>

--- a/index.html
+++ b/index.html
@@ -50,10 +50,10 @@
 				<div class="text-center pb-4">
 					<h1>脱！初心者みくじ</h1>
 				</div>
-				<div class="pb-4">
+				<div class="pb-4 d-flex justify-content-center">
 					<img
-						width="100%"
-						height="100%"
+						width="60%"
+						height="60%"
 						src="./img/ramen_moyashi.png"
 						alt="なんかいい画像"
 					/>

--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
 				</div>
 				<div class="pb-4">
 					<img
-						width="400"
-						height="400"
+						width="100%"
+						height="100%"
 						src="./img/ramen_moyashi.png"
 						alt="なんかいい画像"
 					/>


### PR DESCRIPTION
#7 

・目的
スマホサイズにすると画面右側に余白が発生していたため修正

・不安点
トップページの画像の縦横サイズを100％に変更しています。これが今後の想定を邪魔するものではないか心配しています。

・疑問／課題
result-pageのレスポンシブについて、操作手順によってレスポンシブが崩れるときと崩れない時があります。サイズ設定の「Dimensions: Resopsive」で横幅を小さくしていくと表示崩れが発生しますが、他の選択肢（Ex. iPhoneSE等）だと画面下からoverflowする部分が表示されなくなります。これがレスポンシブ崩れなのか私の確認の仕方の問題なのかがわかりません。