### PR TITLE
おみくじの初期位置を調整

### DIFF
--- a/animation.css
+++ b/animation.css
@@ -7,7 +7,7 @@
 
 @keyframes fall {
 	from {
-		top: -500px;
+		top: -800px;
 	}
 	to {
 		top: 0px;


### PR DESCRIPTION
#18 アニメーションの微調整です。おみくじの初期位置をより上にして画像が読み込まれていない状態をできるだけ見せないようにしました。環境によっては見えますが。